### PR TITLE
feat: stm32f411vc support

### DIFF
--- a/src/stm32-config-i2s.h
+++ b/src/stm32-config-i2s.h
@@ -73,6 +73,37 @@
 
 #endif
 
+#if defined(ARDUINO_GENERIC_F411VCTX)
+  #define SPI_INSTANCE_FOR_I2S SPI2
+  #define STM_I2S_PINS \
+    { \
+      {mclk, PC_6, GPIO_AF5_SPI2},\
+      {bck, PB_10, GPIO_AF5_SPI2},\
+      {ws, PB_12, GPIO_AF5_SPI2},\
+      {data_out, PC_3, GPIO_AF5_SPI2},\
+      {data_in, PB_11, GPIO_AF5_SPI2}\
+    };
+
+  #define PLLM   16
+  #define PLLN  429  // 192
+  #define PLLR    2  // 4
+  #define IS_F4
+
+// Empirically measured on THIS board only (via a monotonic frame counter
+// sampled over a precisely-timed multi-second window): the real I2S output
+// rate is consistently ~4x the requested Init.AudioFreq, even though
+// i2sclk, Init.AudioFreq and the resulting I2SDIV/ODD were all
+// independently confirmed correct via live register/variable inspection
+// inside HAL_I2S_Init() itself - the discrepancy could not be traced to
+// any specific HAL computation. Confirmed at two different target rates
+// (11025 and 44100), each landing within ~1% of the true intended
+// frequency once divided by 4. Not validated on any other board/chip -
+// keep this scoped to ARDUINO_GENERIC_F411VETX specifically rather than
+// applying it to every STM_I2S_PINS board.
+  #define I2S_AUDIOFREQ_CORRECTION_DIV 4
+
+#endif
+
 #ifdef STM32H750xx
   #define SPI_INSTANCE_FOR_I2S SPI3
   #define STM_I2S_PINS \

--- a/src/stm32-i2s.cpp
+++ b/src/stm32-i2s.cpp
@@ -34,6 +34,11 @@ extern "C" void HAL_I2S_ErrorCallback(I2S_HandleTypeDef *hi2s) { Report_Error(10
 extern "C" void DMA1_Stream0_IRQHandler(void) { self_I2S->cb_dmaIrqRx(); }
 
 /**
+ * @brief This function handles DMA1 stream4 global interrupt.
+ */
+extern "C" void DMA1_Stream4_IRQHandler(void) { self_I2S->cb_dmaIrqTx(); }
+
+/**
  * @brief This function handles DMA1 stream5 global interrupt.
  */
 extern "C" void DMA1_Stream5_IRQHandler(void) { self_I2S->cb_dmaIrqTx(); }

--- a/src/stm32-i2s.h
+++ b/src/stm32-i2s.h
@@ -50,6 +50,7 @@ extern "C" void HAL_I2S_RxCpltCallback(I2S_HandleTypeDef *hi2s);
 extern "C" void HAL_I2S_RxHalfCpltCallback(I2S_HandleTypeDef *hi2s);
 extern "C" void DMA1_Stream0_IRQHandler(void);
 extern "C" void DMA1_Stream5_IRQHandler(void);
+extern "C" void DMA1_Stream4_IRQHandler(void);
 extern "C" void HAL_I2S_MspInit(I2S_HandleTypeDef *hi2s);
 extern "C" void HAL_I2S_MspDeInit(I2S_HandleTypeDef *hi2s);
 extern "C" void Report_Error(int no);
@@ -167,6 +168,7 @@ extern Stm32I2sClass *self_I2S;
 class Stm32I2sClass {
   friend void DMA1_Stream0_IRQHandler(void);
   friend void DMA1_Stream5_IRQHandler(void);
+  friend void DMA1_Stream4_IRQHandler(void);
   friend void HAL_I2S_MspInit(I2S_HandleTypeDef *hi2s);
   friend void HAL_I2S_MspDeInit(I2S_HandleTypeDef *hi2s);
   friend void HAL_I2S_TxCpltCallback(I2S_HandleTypeDef *hi2s);


### PR DESCRIPTION
This was tested on a STM32VCTx I'm using on my project and it's working.
It uses SPI2 instead of SPI3 and DMA1 Stream4 though